### PR TITLE
fix: use defensive kotlin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,5 +56,4 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : "1.5.30"
+    def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : "1.5.30"
     repositories {
         google()
         mavenCentral()
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -56,4 +56,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : "1.5.30"
+    def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['ExperimentReactNativeClient_kotlinVersion']
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -19,11 +19,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('ExperimentReactNativeClient_compileSdkVersion', 29)
-    buildToolsVersion safeExtGet('ExperimentReactNativeClient_buildToolsVersion', '29.0.2')
+    compileSdkVersion safeExtGet('ExperimentReactNativeClient_compileSdkVersion', 31)
+    buildToolsVersion safeExtGet('ExperimentReactNativeClient_buildToolsVersion', '31.0.0')
     defaultConfig {
-        minSdkVersion safeExtGet('ExperimentReactNativeClient_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('ExperimentReactNativeClient_targetSdkVersion', 29)
+        minSdkVersion safeExtGet('ExperimentReactNativeClient_minSdkVersion', 21)
+        targetSdkVersion safeExtGet('ExperimentReactNativeClient_targetSdkVersion', 31)
         versionCode 1
         versionName "1.0"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = "1.5.30"
+    ext.kotlinVersion = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : "1.5.30"
     repositories {
         google()
         mavenCentral()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
+ExperimentReactNativeClient_kotlinVersion=1.6.21
+ExperimentReactNativeClient_compileSdkVersion=31
+ExperimentReactNativeClient_buildToolsVersion=31.0.0
+ExperimentReactNativeClient_targetSdkVersion=31
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official


### PR DESCRIPTION
use the defined gradle `ext.kotlinVersion` if defined, otherwise use default version 1.5.30

Should fix #25 