### PR TITLE
`fetch` error logging to use warn instead of error

### DIFF
--- a/src/experimentClient.ts
+++ b/src/experimentClient.ts
@@ -241,7 +241,7 @@ export class ExperimentClient implements Client {
         options,
       );
     } catch (e) {
-      console.error(e);
+      console.warn(e);
     }
     return this;
   }


### PR DESCRIPTION
Simple change from console.error to console.warn in `.fetch` method



motivation:
Users with no internet access can cause `fetch` to throw errors, this can be seen by these errors messages: 
- `"Request timeout after 10000 milliseconds"` 
- `"Network request failed"`

When this sdk is integrated with an app that uses sentry, handling this error with `console.error` can flood sentry issues with users who has internet related problems (timeout or unreachable network).

One way to handle this kind of error would be to check for `response.status === 0`, and ignore this internet related error. 
BUT this pull request suggest an 'one-liner' approach (nothing sofisticated, just a workaround).

Other way (arguably the best way) would be to just throw this exception, and let it break. So the developer (user of this sdk) can handle this kind of error. I would like to see this implementation :) 


tldr;
`@amplitude/experiment-react-native-client` flooding Sentry platform with "Network request failed" and "Request timeout after 10000 milliseconds" with this "console.error"
