### PR TITLE
fix : usage of deprecated toUpper method that cause build errors on Android in  RN .80>=

### DIFF
--- a/android/src/main/java/com/amplitude/experiment/reactnative/AndroidContextProvider.kt
+++ b/android/src/main/java/com/amplitude/experiment/reactnative/AndroidContextProvider.kt
@@ -168,7 +168,7 @@ class AndroidContextProvider(private val context: Context, locationListening: Bo
           if (manager.phoneType != TelephonyManager.PHONE_TYPE_CDMA) {
             val country = manager.networkCountryIso
             if (country != null) {
-              return country.toUpperCase(Locale.US)
+              return country.uppercase(Locale.US)
             }
           }
         } catch (e: Exception) {


### PR DESCRIPTION
toUpperCase is deprecated with error since kotlin 2.1 required by RN v.80>=