### PR TITLE
fix: bump experiment-core dep to bring in array value targeting fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-connector": "^1.4.7",
-    "@amplitude/experiment-core": "^0.11.0",
+    "@amplitude/experiment-core": "^0.13.1",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "unfetch": "^4.2.0"
   },
@@ -108,7 +108,9 @@
     },
     "npm": {
       "publish": true,
-      "publishArgs": ["--provenance"]
+      "publishArgs": [
+        "--provenance"
+      ]
     },
     "github": {
       "release": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.6.4.tgz#8a811ff5c8ee46bdfea0e8f61c7578769b5778ed"
   integrity sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==
 
-"@amplitude/experiment-core@^0.11.0":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@amplitude/experiment-core/-/experiment-core-0.11.1.tgz#31eb485dc40b65f4cc2f15adab9b62f0df622065"
-  integrity sha512-fHVJazCwwgjUcj49N+yFSLMSroyY0eHImrsmd1ipIjIT1Cez8mh+TvwJQ0LGSdyYvL2NAZM2J5vpXrR1nHgdzg==
+"@amplitude/experiment-core@^0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/experiment-core/-/experiment-core-0.13.1.tgz#660dc3952626af0138ff12eb4d161fa63869ad9c"
+  integrity sha512-ZHvR0dxTltasp8MiMcQ6qKsY20mWnODoy3oebGad6qaRR1ywpUi8IuLf5AwLTM35ZwgzEUTn9TEIWKLHpDwHMw==
   dependencies:
     js-base64 "^3.7.5"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dependency upgrade can change runtime targeting/evaluation behavior even though the code changes are minimal and confined to package metadata.
> 
> **Overview**
> Bumps `@amplitude/experiment-core` from `^0.11.0` to `^0.13.1` and updates `yarn.lock` to resolve the new package version.
> 
> Also reformats the `release-it` `npm.publishArgs` entry in `package.json` (no functional change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8fdcad3a224cb0344f72ffe92128574af36db0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->